### PR TITLE
Refactor (definitions): Remove sending definition objects down the pipeline

### DIFF
--- a/generate/definitions/FILES.ps1
+++ b/generate/definitions/FILES.ps1
@@ -6,6 +6,3 @@ $FILES = @(
     # '.gitlab-ci.yml'
     'README.md'
 )
-
-# Send definitions down the pipeline
-$FILES

--- a/generate/definitions/VARIANTS.ps1
+++ b/generate/definitions/VARIANTS.ps1
@@ -118,6 +118,3 @@ $VARIANTS_SHARED = @{
         }
     }
 }
-
-# Send definitions down the pipeline
-$VARIANTS


### PR DESCRIPTION
Sending down the pipeline is no longer need as of `Generate-DockerImageVariants v0.3.0`