### PR TITLE
Change: Remove `v` prefix from docker tags

### DIFF
--- a/.github/workflows/ci-master-pr.yml
+++ b/.github/workflows/ci-master-pr.yml
@@ -79,7 +79,7 @@ jobs:
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v8-4-0-alpine-edge
+      id: prep-8-4-0-alpine-edge
       run: |
         set -e
 
@@ -92,7 +92,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v8.4.0-alpine-edge"
+        VARIANT="8.4.0-alpine-edge"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -102,52 +102,52 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v8.4.0-alpine-edge - Build (PRs)
+    - name: 8.4.0-alpine-edge - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v8.4.0-alpine-edge
+        context: variants/8.4.0-alpine-edge
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v8-4-0-alpine-edge.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v8-4-0-alpine-edge.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-8-4-0-alpine-edge.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-8-4-0-alpine-edge.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v8.4.0-alpine-edge - Build and push (master)
+    - name: 8.4.0-alpine-edge - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v8.4.0-alpine-edge
+        context: variants/8.4.0-alpine-edge
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v8-4-0-alpine-edge.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v8-4-0-alpine-edge.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-8-4-0-alpine-edge.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-8-4-0-alpine-edge.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v8.4.0-alpine-edge - Build and push (release)
+    - name: 8.4.0-alpine-edge - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v8.4.0-alpine-edge
+        context: variants/8.4.0-alpine-edge
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v8-4-0-alpine-edge.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v8-4-0-alpine-edge.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v8-4-0-alpine-edge.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-8-4-0-alpine-edge.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-8-4-0-alpine-edge.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-8-4-0-alpine-edge.outputs.REF_SHA_VARIANT }}
           ${{ github.repository }}:latest
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v8-4-0-sops-ssh-alpine-edge
+      id: prep-8-4-0-sops-ssh-alpine-edge
       run: |
         set -e
 
@@ -160,7 +160,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v8.4.0-sops-ssh-alpine-edge"
+        VARIANT="8.4.0-sops-ssh-alpine-edge"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -170,45 +170,45 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v8.4.0-sops-ssh-alpine-edge - Build (PRs)
+    - name: 8.4.0-sops-ssh-alpine-edge - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v8.4.0-sops-ssh-alpine-edge
+        context: variants/8.4.0-sops-ssh-alpine-edge
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v8-4-0-sops-ssh-alpine-edge.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v8-4-0-sops-ssh-alpine-edge.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-8-4-0-sops-ssh-alpine-edge.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-8-4-0-sops-ssh-alpine-edge.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v8.4.0-sops-ssh-alpine-edge - Build and push (master)
+    - name: 8.4.0-sops-ssh-alpine-edge - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v8.4.0-sops-ssh-alpine-edge
+        context: variants/8.4.0-sops-ssh-alpine-edge
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v8-4-0-sops-ssh-alpine-edge.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v8-4-0-sops-ssh-alpine-edge.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-8-4-0-sops-ssh-alpine-edge.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-8-4-0-sops-ssh-alpine-edge.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v8.4.0-sops-ssh-alpine-edge - Build and push (release)
+    - name: 8.4.0-sops-ssh-alpine-edge - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v8.4.0-sops-ssh-alpine-edge
+        context: variants/8.4.0-sops-ssh-alpine-edge
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v8-4-0-sops-ssh-alpine-edge.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v8-4-0-sops-ssh-alpine-edge.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v8-4-0-sops-ssh-alpine-edge.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-8-4-0-sops-ssh-alpine-edge.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-8-4-0-sops-ssh-alpine-edge.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-8-4-0-sops-ssh-alpine-edge.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
@@ -266,7 +266,7 @@ jobs:
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v7-5-0-alpine-3-18
+      id: prep-7-5-0-alpine-3-18
       run: |
         set -e
 
@@ -279,7 +279,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v7.5.0-alpine-3.18"
+        VARIANT="7.5.0-alpine-3.18"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -289,51 +289,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v7.5.0-alpine-3.18 - Build (PRs)
+    - name: 7.5.0-alpine-3.18 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v7.5.0-alpine-3.18
+        context: variants/7.5.0-alpine-3.18
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v7-5-0-alpine-3-18.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v7-5-0-alpine-3-18.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-7-5-0-alpine-3-18.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-7-5-0-alpine-3-18.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v7.5.0-alpine-3.18 - Build and push (master)
+    - name: 7.5.0-alpine-3.18 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v7.5.0-alpine-3.18
+        context: variants/7.5.0-alpine-3.18
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v7-5-0-alpine-3-18.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v7-5-0-alpine-3-18.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-7-5-0-alpine-3-18.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-7-5-0-alpine-3-18.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v7.5.0-alpine-3.18 - Build and push (release)
+    - name: 7.5.0-alpine-3.18 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v7.5.0-alpine-3.18
+        context: variants/7.5.0-alpine-3.18
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v7-5-0-alpine-3-18.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v7-5-0-alpine-3-18.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v7-5-0-alpine-3-18.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-7-5-0-alpine-3-18.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-7-5-0-alpine-3-18.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-7-5-0-alpine-3-18.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v7-5-0-sops-ssh-alpine-3-18
+      id: prep-7-5-0-sops-ssh-alpine-3-18
       run: |
         set -e
 
@@ -346,7 +346,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v7.5.0-sops-ssh-alpine-3.18"
+        VARIANT="7.5.0-sops-ssh-alpine-3.18"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -356,45 +356,45 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v7.5.0-sops-ssh-alpine-3.18 - Build (PRs)
+    - name: 7.5.0-sops-ssh-alpine-3.18 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v7.5.0-sops-ssh-alpine-3.18
+        context: variants/7.5.0-sops-ssh-alpine-3.18
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v7-5-0-sops-ssh-alpine-3-18.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v7-5-0-sops-ssh-alpine-3-18.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-7-5-0-sops-ssh-alpine-3-18.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-7-5-0-sops-ssh-alpine-3-18.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v7.5.0-sops-ssh-alpine-3.18 - Build and push (master)
+    - name: 7.5.0-sops-ssh-alpine-3.18 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v7.5.0-sops-ssh-alpine-3.18
+        context: variants/7.5.0-sops-ssh-alpine-3.18
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v7-5-0-sops-ssh-alpine-3-18.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v7-5-0-sops-ssh-alpine-3-18.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-7-5-0-sops-ssh-alpine-3-18.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-7-5-0-sops-ssh-alpine-3-18.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v7.5.0-sops-ssh-alpine-3.18 - Build and push (release)
+    - name: 7.5.0-sops-ssh-alpine-3.18 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v7.5.0-sops-ssh-alpine-3.18
+        context: variants/7.5.0-sops-ssh-alpine-3.18
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v7-5-0-sops-ssh-alpine-3-18.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v7-5-0-sops-ssh-alpine-3-18.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v7-5-0-sops-ssh-alpine-3-18.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-7-5-0-sops-ssh-alpine-3-18.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-7-5-0-sops-ssh-alpine-3-18.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-7-5-0-sops-ssh-alpine-3-18.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
@@ -452,7 +452,7 @@ jobs:
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v6-6-0-alpine-3-17
+      id: prep-6-6-0-alpine-3-17
       run: |
         set -e
 
@@ -465,7 +465,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v6.6.0-alpine-3.17"
+        VARIANT="6.6.0-alpine-3.17"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -475,51 +475,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v6.6.0-alpine-3.17 - Build (PRs)
+    - name: 6.6.0-alpine-3.17 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v6.6.0-alpine-3.17
+        context: variants/6.6.0-alpine-3.17
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v6-6-0-alpine-3-17.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v6-6-0-alpine-3-17.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-6-6-0-alpine-3-17.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-6-6-0-alpine-3-17.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v6.6.0-alpine-3.17 - Build and push (master)
+    - name: 6.6.0-alpine-3.17 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v6.6.0-alpine-3.17
+        context: variants/6.6.0-alpine-3.17
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v6-6-0-alpine-3-17.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v6-6-0-alpine-3-17.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-6-6-0-alpine-3-17.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-6-6-0-alpine-3-17.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v6.6.0-alpine-3.17 - Build and push (release)
+    - name: 6.6.0-alpine-3.17 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v6.6.0-alpine-3.17
+        context: variants/6.6.0-alpine-3.17
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v6-6-0-alpine-3-17.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v6-6-0-alpine-3-17.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v6-6-0-alpine-3-17.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-6-6-0-alpine-3-17.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-6-6-0-alpine-3-17.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-6-6-0-alpine-3-17.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v6-6-0-sops-ssh-alpine-3-17
+      id: prep-6-6-0-sops-ssh-alpine-3-17
       run: |
         set -e
 
@@ -532,7 +532,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v6.6.0-sops-ssh-alpine-3.17"
+        VARIANT="6.6.0-sops-ssh-alpine-3.17"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -542,45 +542,45 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v6.6.0-sops-ssh-alpine-3.17 - Build (PRs)
+    - name: 6.6.0-sops-ssh-alpine-3.17 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v6.6.0-sops-ssh-alpine-3.17
+        context: variants/6.6.0-sops-ssh-alpine-3.17
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v6-6-0-sops-ssh-alpine-3-17.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v6-6-0-sops-ssh-alpine-3-17.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-6-6-0-sops-ssh-alpine-3-17.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-6-6-0-sops-ssh-alpine-3-17.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v6.6.0-sops-ssh-alpine-3.17 - Build and push (master)
+    - name: 6.6.0-sops-ssh-alpine-3.17 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v6.6.0-sops-ssh-alpine-3.17
+        context: variants/6.6.0-sops-ssh-alpine-3.17
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v6-6-0-sops-ssh-alpine-3-17.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v6-6-0-sops-ssh-alpine-3-17.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-6-6-0-sops-ssh-alpine-3-17.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-6-6-0-sops-ssh-alpine-3-17.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v6.6.0-sops-ssh-alpine-3.17 - Build and push (release)
+    - name: 6.6.0-sops-ssh-alpine-3.17 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v6.6.0-sops-ssh-alpine-3.17
+        context: variants/6.6.0-sops-ssh-alpine-3.17
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v6-6-0-sops-ssh-alpine-3-17.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v6-6-0-sops-ssh-alpine-3-17.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v6-6-0-sops-ssh-alpine-3-17.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-6-6-0-sops-ssh-alpine-3-17.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-6-6-0-sops-ssh-alpine-3-17.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-6-6-0-sops-ssh-alpine-3-17.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
@@ -638,7 +638,7 @@ jobs:
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v5-8-0-alpine-3-16
+      id: prep-5-8-0-alpine-3-16
       run: |
         set -e
 
@@ -651,7 +651,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v5.8.0-alpine-3.16"
+        VARIANT="5.8.0-alpine-3.16"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -661,51 +661,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v5.8.0-alpine-3.16 - Build (PRs)
+    - name: 5.8.0-alpine-3.16 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v5.8.0-alpine-3.16
+        context: variants/5.8.0-alpine-3.16
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v5-8-0-alpine-3-16.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v5-8-0-alpine-3-16.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-5-8-0-alpine-3-16.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-5-8-0-alpine-3-16.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v5.8.0-alpine-3.16 - Build and push (master)
+    - name: 5.8.0-alpine-3.16 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v5.8.0-alpine-3.16
+        context: variants/5.8.0-alpine-3.16
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v5-8-0-alpine-3-16.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v5-8-0-alpine-3-16.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-5-8-0-alpine-3-16.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-5-8-0-alpine-3-16.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v5.8.0-alpine-3.16 - Build and push (release)
+    - name: 5.8.0-alpine-3.16 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v5.8.0-alpine-3.16
+        context: variants/5.8.0-alpine-3.16
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v5-8-0-alpine-3-16.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v5-8-0-alpine-3-16.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v5-8-0-alpine-3-16.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-5-8-0-alpine-3-16.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-5-8-0-alpine-3-16.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-5-8-0-alpine-3-16.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v5-8-0-sops-ssh-alpine-3-16
+      id: prep-5-8-0-sops-ssh-alpine-3-16
       run: |
         set -e
 
@@ -718,7 +718,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v5.8.0-sops-ssh-alpine-3.16"
+        VARIANT="5.8.0-sops-ssh-alpine-3.16"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -728,45 +728,45 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v5.8.0-sops-ssh-alpine-3.16 - Build (PRs)
+    - name: 5.8.0-sops-ssh-alpine-3.16 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v5.8.0-sops-ssh-alpine-3.16
+        context: variants/5.8.0-sops-ssh-alpine-3.16
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v5-8-0-sops-ssh-alpine-3-16.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v5-8-0-sops-ssh-alpine-3-16.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-5-8-0-sops-ssh-alpine-3-16.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-5-8-0-sops-ssh-alpine-3-16.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v5.8.0-sops-ssh-alpine-3.16 - Build and push (master)
+    - name: 5.8.0-sops-ssh-alpine-3.16 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v5.8.0-sops-ssh-alpine-3.16
+        context: variants/5.8.0-sops-ssh-alpine-3.16
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v5-8-0-sops-ssh-alpine-3-16.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v5-8-0-sops-ssh-alpine-3-16.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-5-8-0-sops-ssh-alpine-3-16.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-5-8-0-sops-ssh-alpine-3-16.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v5.8.0-sops-ssh-alpine-3.16 - Build and push (release)
+    - name: 5.8.0-sops-ssh-alpine-3.16 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v5.8.0-sops-ssh-alpine-3.16
+        context: variants/5.8.0-sops-ssh-alpine-3.16
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v5-8-0-sops-ssh-alpine-3-16.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v5-8-0-sops-ssh-alpine-3-16.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v5-8-0-sops-ssh-alpine-3-16.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-5-8-0-sops-ssh-alpine-3-16.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-5-8-0-sops-ssh-alpine-3-16.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-5-8-0-sops-ssh-alpine-3-16.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
@@ -824,7 +824,7 @@ jobs:
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v4-8-0-alpine-3-15
+      id: prep-4-8-0-alpine-3-15
       run: |
         set -e
 
@@ -837,7 +837,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v4.8.0-alpine-3.15"
+        VARIANT="4.8.0-alpine-3.15"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -847,51 +847,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v4.8.0-alpine-3.15 - Build (PRs)
+    - name: 4.8.0-alpine-3.15 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.8.0-alpine-3.15
+        context: variants/4.8.0-alpine-3.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-8-0-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-8-0-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-4-8-0-alpine-3-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-4-8-0-alpine-3-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.8.0-alpine-3.15 - Build and push (master)
+    - name: 4.8.0-alpine-3.15 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.8.0-alpine-3.15
+        context: variants/4.8.0-alpine-3.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-8-0-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-8-0-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-4-8-0-alpine-3-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-4-8-0-alpine-3-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.8.0-alpine-3.15 - Build and push (release)
+    - name: 4.8.0-alpine-3.15 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.8.0-alpine-3.15
+        context: variants/4.8.0-alpine-3.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-8-0-alpine-3-15.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-8-0-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-8-0-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-4-8-0-alpine-3-15.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-4-8-0-alpine-3-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-4-8-0-alpine-3-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v4-8-0-sops-ssh-alpine-3-15
+      id: prep-4-8-0-sops-ssh-alpine-3-15
       run: |
         set -e
 
@@ -904,7 +904,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v4.8.0-sops-ssh-alpine-3.15"
+        VARIANT="4.8.0-sops-ssh-alpine-3.15"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -914,45 +914,45 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v4.8.0-sops-ssh-alpine-3.15 - Build (PRs)
+    - name: 4.8.0-sops-ssh-alpine-3.15 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.8.0-sops-ssh-alpine-3.15
+        context: variants/4.8.0-sops-ssh-alpine-3.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-8-0-sops-ssh-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-8-0-sops-ssh-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-4-8-0-sops-ssh-alpine-3-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-4-8-0-sops-ssh-alpine-3-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.8.0-sops-ssh-alpine-3.15 - Build and push (master)
+    - name: 4.8.0-sops-ssh-alpine-3.15 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.8.0-sops-ssh-alpine-3.15
+        context: variants/4.8.0-sops-ssh-alpine-3.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-8-0-sops-ssh-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-8-0-sops-ssh-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-4-8-0-sops-ssh-alpine-3-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-4-8-0-sops-ssh-alpine-3-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v4.8.0-sops-ssh-alpine-3.15 - Build and push (release)
+    - name: 4.8.0-sops-ssh-alpine-3.15 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v4.8.0-sops-ssh-alpine-3.15
+        context: variants/4.8.0-sops-ssh-alpine-3.15
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v4-8-0-sops-ssh-alpine-3-15.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-8-0-sops-ssh-alpine-3-15.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v4-8-0-sops-ssh-alpine-3-15.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-4-8-0-sops-ssh-alpine-3-15.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-4-8-0-sops-ssh-alpine-3-15.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-4-8-0-sops-ssh-alpine-3-15.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
@@ -1010,7 +1010,7 @@ jobs:
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v2-10-7-alpine-3-13
+      id: prep-2-10-7-alpine-3-13
       run: |
         set -e
 
@@ -1023,7 +1023,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v2.10.7-alpine-3.13"
+        VARIANT="2.10.7-alpine-3.13"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -1033,51 +1033,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v2.10.7-alpine-3.13 - Build (PRs)
+    - name: 2.10.7-alpine-3.13 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v2.10.7-alpine-3.13
+        context: variants/2.10.7-alpine-3.13
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v2-10-7-alpine-3-13.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-10-7-alpine-3-13.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-10-7-alpine-3-13.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-10-7-alpine-3-13.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v2.10.7-alpine-3.13 - Build and push (master)
+    - name: 2.10.7-alpine-3.13 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v2.10.7-alpine-3.13
+        context: variants/2.10.7-alpine-3.13
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v2-10-7-alpine-3-13.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-10-7-alpine-3-13.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-10-7-alpine-3-13.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-10-7-alpine-3-13.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v2.10.7-alpine-3.13 - Build and push (release)
+    - name: 2.10.7-alpine-3.13 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v2.10.7-alpine-3.13
+        context: variants/2.10.7-alpine-3.13
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v2-10-7-alpine-3-13.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-10-7-alpine-3-13.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-10-7-alpine-3-13.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-10-7-alpine-3-13.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-10-7-alpine-3-13.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-10-7-alpine-3-13.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v2-10-7-sops-ssh-alpine-3-13
+      id: prep-2-10-7-sops-ssh-alpine-3-13
       run: |
         set -e
 
@@ -1090,7 +1090,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v2.10.7-sops-ssh-alpine-3.13"
+        VARIANT="2.10.7-sops-ssh-alpine-3.13"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -1100,45 +1100,45 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v2.10.7-sops-ssh-alpine-3.13 - Build (PRs)
+    - name: 2.10.7-sops-ssh-alpine-3.13 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v2.10.7-sops-ssh-alpine-3.13
+        context: variants/2.10.7-sops-ssh-alpine-3.13
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v2-10-7-sops-ssh-alpine-3-13.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-10-7-sops-ssh-alpine-3-13.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-10-7-sops-ssh-alpine-3-13.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-10-7-sops-ssh-alpine-3-13.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v2.10.7-sops-ssh-alpine-3.13 - Build and push (master)
+    - name: 2.10.7-sops-ssh-alpine-3.13 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v2.10.7-sops-ssh-alpine-3.13
+        context: variants/2.10.7-sops-ssh-alpine-3.13
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v2-10-7-sops-ssh-alpine-3-13.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-10-7-sops-ssh-alpine-3-13.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-10-7-sops-ssh-alpine-3-13.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-10-7-sops-ssh-alpine-3-13.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v2.10.7-sops-ssh-alpine-3.13 - Build and push (release)
+    - name: 2.10.7-sops-ssh-alpine-3.13 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v2.10.7-sops-ssh-alpine-3.13
+        context: variants/2.10.7-sops-ssh-alpine-3.13
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v2-10-7-sops-ssh-alpine-3-13.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-10-7-sops-ssh-alpine-3-13.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-10-7-sops-ssh-alpine-3-13.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-10-7-sops-ssh-alpine-3-13.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-10-7-sops-ssh-alpine-3-13.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-10-7-sops-ssh-alpine-3-13.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
@@ -1196,7 +1196,7 @@ jobs:
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v2-9-18-alpine-3-11
+      id: prep-2-9-18-alpine-3-11
       run: |
         set -e
 
@@ -1209,7 +1209,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v2.9.18-alpine-3.11"
+        VARIANT="2.9.18-alpine-3.11"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -1219,51 +1219,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v2.9.18-alpine-3.11 - Build (PRs)
+    - name: 2.9.18-alpine-3.11 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v2.9.18-alpine-3.11
+        context: variants/2.9.18-alpine-3.11
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v2-9-18-alpine-3-11.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-9-18-alpine-3-11.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-9-18-alpine-3-11.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-9-18-alpine-3-11.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v2.9.18-alpine-3.11 - Build and push (master)
+    - name: 2.9.18-alpine-3.11 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v2.9.18-alpine-3.11
+        context: variants/2.9.18-alpine-3.11
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v2-9-18-alpine-3-11.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-9-18-alpine-3-11.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-9-18-alpine-3-11.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-9-18-alpine-3-11.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v2.9.18-alpine-3.11 - Build and push (release)
+    - name: 2.9.18-alpine-3.11 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v2.9.18-alpine-3.11
+        context: variants/2.9.18-alpine-3.11
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v2-9-18-alpine-3-11.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-9-18-alpine-3-11.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-9-18-alpine-3-11.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-9-18-alpine-3-11.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-9-18-alpine-3-11.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-9-18-alpine-3-11.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v2-9-18-sops-ssh-alpine-3-11
+      id: prep-2-9-18-sops-ssh-alpine-3-11
       run: |
         set -e
 
@@ -1276,7 +1276,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v2.9.18-sops-ssh-alpine-3.11"
+        VARIANT="2.9.18-sops-ssh-alpine-3.11"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -1286,45 +1286,45 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v2.9.18-sops-ssh-alpine-3.11 - Build (PRs)
+    - name: 2.9.18-sops-ssh-alpine-3.11 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v2.9.18-sops-ssh-alpine-3.11
+        context: variants/2.9.18-sops-ssh-alpine-3.11
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v2-9-18-sops-ssh-alpine-3-11.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-9-18-sops-ssh-alpine-3-11.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-9-18-sops-ssh-alpine-3-11.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-9-18-sops-ssh-alpine-3-11.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v2.9.18-sops-ssh-alpine-3.11 - Build and push (master)
+    - name: 2.9.18-sops-ssh-alpine-3.11 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v2.9.18-sops-ssh-alpine-3.11
+        context: variants/2.9.18-sops-ssh-alpine-3.11
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v2-9-18-sops-ssh-alpine-3-11.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-9-18-sops-ssh-alpine-3-11.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-9-18-sops-ssh-alpine-3-11.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-9-18-sops-ssh-alpine-3-11.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v2.9.18-sops-ssh-alpine-3.11 - Build and push (release)
+    - name: 2.9.18-sops-ssh-alpine-3.11 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v2.9.18-sops-ssh-alpine-3.11
+        context: variants/2.9.18-sops-ssh-alpine-3.11
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v2-9-18-sops-ssh-alpine-3-11.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-9-18-sops-ssh-alpine-3-11.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-9-18-sops-ssh-alpine-3-11.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-9-18-sops-ssh-alpine-3-11.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-9-18-sops-ssh-alpine-3-11.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-9-18-sops-ssh-alpine-3-11.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
@@ -1382,7 +1382,7 @@ jobs:
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v2-8-19-alpine-3-10
+      id: prep-2-8-19-alpine-3-10
       run: |
         set -e
 
@@ -1395,7 +1395,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v2.8.19-alpine-3.10"
+        VARIANT="2.8.19-alpine-3.10"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -1405,51 +1405,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v2.8.19-alpine-3.10 - Build (PRs)
+    - name: 2.8.19-alpine-3.10 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v2.8.19-alpine-3.10
+        context: variants/2.8.19-alpine-3.10
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v2-8-19-alpine-3-10.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-8-19-alpine-3-10.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-8-19-alpine-3-10.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-8-19-alpine-3-10.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v2.8.19-alpine-3.10 - Build and push (master)
+    - name: 2.8.19-alpine-3.10 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v2.8.19-alpine-3.10
+        context: variants/2.8.19-alpine-3.10
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v2-8-19-alpine-3-10.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-8-19-alpine-3-10.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-8-19-alpine-3-10.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-8-19-alpine-3-10.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v2.8.19-alpine-3.10 - Build and push (release)
+    - name: 2.8.19-alpine-3.10 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v2.8.19-alpine-3.10
+        context: variants/2.8.19-alpine-3.10
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v2-8-19-alpine-3-10.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-8-19-alpine-3-10.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-8-19-alpine-3-10.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-8-19-alpine-3-10.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-8-19-alpine-3-10.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-8-19-alpine-3-10.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v2-8-19-sops-ssh-alpine-3-10
+      id: prep-2-8-19-sops-ssh-alpine-3-10
       run: |
         set -e
 
@@ -1462,7 +1462,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v2.8.19-sops-ssh-alpine-3.10"
+        VARIANT="2.8.19-sops-ssh-alpine-3.10"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -1472,45 +1472,45 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v2.8.19-sops-ssh-alpine-3.10 - Build (PRs)
+    - name: 2.8.19-sops-ssh-alpine-3.10 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v2.8.19-sops-ssh-alpine-3.10
+        context: variants/2.8.19-sops-ssh-alpine-3.10
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v2-8-19-sops-ssh-alpine-3-10.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-8-19-sops-ssh-alpine-3-10.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-8-19-sops-ssh-alpine-3-10.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-8-19-sops-ssh-alpine-3-10.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v2.8.19-sops-ssh-alpine-3.10 - Build and push (master)
+    - name: 2.8.19-sops-ssh-alpine-3.10 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v2.8.19-sops-ssh-alpine-3.10
+        context: variants/2.8.19-sops-ssh-alpine-3.10
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v2-8-19-sops-ssh-alpine-3-10.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-8-19-sops-ssh-alpine-3-10.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-8-19-sops-ssh-alpine-3-10.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-8-19-sops-ssh-alpine-3-10.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v2.8.19-sops-ssh-alpine-3.10 - Build and push (release)
+    - name: 2.8.19-sops-ssh-alpine-3.10 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v2.8.19-sops-ssh-alpine-3.10
+        context: variants/2.8.19-sops-ssh-alpine-3.10
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v2-8-19-sops-ssh-alpine-3-10.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-8-19-sops-ssh-alpine-3-10.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-8-19-sops-ssh-alpine-3-10.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-8-19-sops-ssh-alpine-3-10.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-8-19-sops-ssh-alpine-3-10.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-8-19-sops-ssh-alpine-3-10.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
@@ -1568,7 +1568,7 @@ jobs:
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v2-7-17-alpine-3-9
+      id: prep-2-7-17-alpine-3-9
       run: |
         set -e
 
@@ -1581,7 +1581,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v2.7.17-alpine-3.9"
+        VARIANT="2.7.17-alpine-3.9"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -1591,51 +1591,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v2.7.17-alpine-3.9 - Build (PRs)
+    - name: 2.7.17-alpine-3.9 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v2.7.17-alpine-3.9
+        context: variants/2.7.17-alpine-3.9
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v2-7-17-alpine-3-9.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-7-17-alpine-3-9.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-7-17-alpine-3-9.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-7-17-alpine-3-9.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v2.7.17-alpine-3.9 - Build and push (master)
+    - name: 2.7.17-alpine-3.9 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v2.7.17-alpine-3.9
+        context: variants/2.7.17-alpine-3.9
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v2-7-17-alpine-3-9.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-7-17-alpine-3-9.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-7-17-alpine-3-9.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-7-17-alpine-3-9.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v2.7.17-alpine-3.9 - Build and push (release)
+    - name: 2.7.17-alpine-3.9 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v2.7.17-alpine-3.9
+        context: variants/2.7.17-alpine-3.9
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v2-7-17-alpine-3-9.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-7-17-alpine-3-9.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-7-17-alpine-3-9.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-7-17-alpine-3-9.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-7-17-alpine-3-9.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-7-17-alpine-3-9.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v2-7-17-sops-ssh-alpine-3-9
+      id: prep-2-7-17-sops-ssh-alpine-3-9
       run: |
         set -e
 
@@ -1648,7 +1648,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v2.7.17-sops-ssh-alpine-3.9"
+        VARIANT="2.7.17-sops-ssh-alpine-3.9"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -1658,45 +1658,45 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v2.7.17-sops-ssh-alpine-3.9 - Build (PRs)
+    - name: 2.7.17-sops-ssh-alpine-3.9 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v2.7.17-sops-ssh-alpine-3.9
+        context: variants/2.7.17-sops-ssh-alpine-3.9
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v2-7-17-sops-ssh-alpine-3-9.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-7-17-sops-ssh-alpine-3-9.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-7-17-sops-ssh-alpine-3-9.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-7-17-sops-ssh-alpine-3-9.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v2.7.17-sops-ssh-alpine-3.9 - Build and push (master)
+    - name: 2.7.17-sops-ssh-alpine-3.9 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v2.7.17-sops-ssh-alpine-3.9
+        context: variants/2.7.17-sops-ssh-alpine-3.9
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v2-7-17-sops-ssh-alpine-3-9.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-7-17-sops-ssh-alpine-3-9.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-7-17-sops-ssh-alpine-3-9.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-7-17-sops-ssh-alpine-3-9.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v2.7.17-sops-ssh-alpine-3.9 - Build and push (release)
+    - name: 2.7.17-sops-ssh-alpine-3.9 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v2.7.17-sops-ssh-alpine-3.9
+        context: variants/2.7.17-sops-ssh-alpine-3.9
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v2-7-17-sops-ssh-alpine-3-9.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-7-17-sops-ssh-alpine-3-9.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-7-17-sops-ssh-alpine-3-9.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-7-17-sops-ssh-alpine-3-9.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-7-17-sops-ssh-alpine-3-9.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-7-17-sops-ssh-alpine-3-9.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
@@ -1754,7 +1754,7 @@ jobs:
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v2-6-20-alpine-3-8
+      id: prep-2-6-20-alpine-3-8
       run: |
         set -e
 
@@ -1767,7 +1767,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v2.6.20-alpine-3.8"
+        VARIANT="2.6.20-alpine-3.8"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -1777,51 +1777,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v2.6.20-alpine-3.8 - Build (PRs)
+    - name: 2.6.20-alpine-3.8 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v2.6.20-alpine-3.8
+        context: variants/2.6.20-alpine-3.8
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v2-6-20-alpine-3-8.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-6-20-alpine-3-8.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-6-20-alpine-3-8.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-6-20-alpine-3-8.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v2.6.20-alpine-3.8 - Build and push (master)
+    - name: 2.6.20-alpine-3.8 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v2.6.20-alpine-3.8
+        context: variants/2.6.20-alpine-3.8
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v2-6-20-alpine-3-8.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-6-20-alpine-3-8.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-6-20-alpine-3-8.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-6-20-alpine-3-8.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v2.6.20-alpine-3.8 - Build and push (release)
+    - name: 2.6.20-alpine-3.8 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v2.6.20-alpine-3.8
+        context: variants/2.6.20-alpine-3.8
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v2-6-20-alpine-3-8.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-6-20-alpine-3-8.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-6-20-alpine-3-8.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-6-20-alpine-3-8.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-6-20-alpine-3-8.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-6-20-alpine-3-8.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v2-6-20-sops-ssh-alpine-3-8
+      id: prep-2-6-20-sops-ssh-alpine-3-8
       run: |
         set -e
 
@@ -1834,7 +1834,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v2.6.20-sops-ssh-alpine-3.8"
+        VARIANT="2.6.20-sops-ssh-alpine-3.8"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -1844,45 +1844,45 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v2.6.20-sops-ssh-alpine-3.8 - Build (PRs)
+    - name: 2.6.20-sops-ssh-alpine-3.8 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v2.6.20-sops-ssh-alpine-3.8
+        context: variants/2.6.20-sops-ssh-alpine-3.8
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v2-6-20-sops-ssh-alpine-3-8.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-6-20-sops-ssh-alpine-3-8.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-6-20-sops-ssh-alpine-3-8.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-6-20-sops-ssh-alpine-3-8.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v2.6.20-sops-ssh-alpine-3.8 - Build and push (master)
+    - name: 2.6.20-sops-ssh-alpine-3.8 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v2.6.20-sops-ssh-alpine-3.8
+        context: variants/2.6.20-sops-ssh-alpine-3.8
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v2-6-20-sops-ssh-alpine-3-8.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-6-20-sops-ssh-alpine-3-8.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-6-20-sops-ssh-alpine-3-8.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-6-20-sops-ssh-alpine-3-8.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v2.6.20-sops-ssh-alpine-3.8 - Build and push (release)
+    - name: 2.6.20-sops-ssh-alpine-3.8 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v2.6.20-sops-ssh-alpine-3.8
+        context: variants/2.6.20-sops-ssh-alpine-3.8
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v2-6-20-sops-ssh-alpine-3-8.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-6-20-sops-ssh-alpine-3-8.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-6-20-sops-ssh-alpine-3-8.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-6-20-sops-ssh-alpine-3-8.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-6-20-sops-ssh-alpine-3-8.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-6-20-sops-ssh-alpine-3-8.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
@@ -1940,7 +1940,7 @@ jobs:
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v2-4-6-0-alpine-3-7
+      id: prep-2-4-6-0-alpine-3-7
       run: |
         set -e
 
@@ -1953,7 +1953,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v2.4.6.0-alpine-3.7"
+        VARIANT="2.4.6.0-alpine-3.7"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -1963,51 +1963,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v2.4.6.0-alpine-3.7 - Build (PRs)
+    - name: 2.4.6.0-alpine-3.7 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v2.4.6.0-alpine-3.7
+        context: variants/2.4.6.0-alpine-3.7
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v2-4-6-0-alpine-3-7.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-4-6-0-alpine-3-7.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-4-6-0-alpine-3-7.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-4-6-0-alpine-3-7.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v2.4.6.0-alpine-3.7 - Build and push (master)
+    - name: 2.4.6.0-alpine-3.7 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v2.4.6.0-alpine-3.7
+        context: variants/2.4.6.0-alpine-3.7
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v2-4-6-0-alpine-3-7.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-4-6-0-alpine-3-7.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-4-6-0-alpine-3-7.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-4-6-0-alpine-3-7.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v2.4.6.0-alpine-3.7 - Build and push (release)
+    - name: 2.4.6.0-alpine-3.7 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v2.4.6.0-alpine-3.7
+        context: variants/2.4.6.0-alpine-3.7
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v2-4-6-0-alpine-3-7.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-4-6-0-alpine-3-7.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-4-6-0-alpine-3-7.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-4-6-0-alpine-3-7.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-4-6-0-alpine-3-7.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-4-6-0-alpine-3-7.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v2-4-6-0-sops-ssh-alpine-3-7
+      id: prep-2-4-6-0-sops-ssh-alpine-3-7
       run: |
         set -e
 
@@ -2020,7 +2020,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v2.4.6.0-sops-ssh-alpine-3.7"
+        VARIANT="2.4.6.0-sops-ssh-alpine-3.7"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -2030,45 +2030,45 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v2.4.6.0-sops-ssh-alpine-3.7 - Build (PRs)
+    - name: 2.4.6.0-sops-ssh-alpine-3.7 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v2.4.6.0-sops-ssh-alpine-3.7
+        context: variants/2.4.6.0-sops-ssh-alpine-3.7
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v2-4-6-0-sops-ssh-alpine-3-7.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-4-6-0-sops-ssh-alpine-3-7.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-4-6-0-sops-ssh-alpine-3-7.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-4-6-0-sops-ssh-alpine-3-7.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v2.4.6.0-sops-ssh-alpine-3.7 - Build and push (master)
+    - name: 2.4.6.0-sops-ssh-alpine-3.7 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v2.4.6.0-sops-ssh-alpine-3.7
+        context: variants/2.4.6.0-sops-ssh-alpine-3.7
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v2-4-6-0-sops-ssh-alpine-3-7.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-4-6-0-sops-ssh-alpine-3-7.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-4-6-0-sops-ssh-alpine-3-7.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-4-6-0-sops-ssh-alpine-3-7.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v2.4.6.0-sops-ssh-alpine-3.7 - Build and push (release)
+    - name: 2.4.6.0-sops-ssh-alpine-3.7 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v2.4.6.0-sops-ssh-alpine-3.7
+        context: variants/2.4.6.0-sops-ssh-alpine-3.7
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v2-4-6-0-sops-ssh-alpine-3-7.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-4-6-0-sops-ssh-alpine-3-7.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-4-6-0-sops-ssh-alpine-3-7.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-4-6-0-sops-ssh-alpine-3-7.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-4-6-0-sops-ssh-alpine-3-7.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-4-6-0-sops-ssh-alpine-3-7.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
@@ -2126,7 +2126,7 @@ jobs:
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v2-3-0-0-alpine-3-6
+      id: prep-2-3-0-0-alpine-3-6
       run: |
         set -e
 
@@ -2139,7 +2139,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v2.3.0.0-alpine-3.6"
+        VARIANT="2.3.0.0-alpine-3.6"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -2149,51 +2149,51 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v2.3.0.0-alpine-3.6 - Build (PRs)
+    - name: 2.3.0.0-alpine-3.6 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v2.3.0.0-alpine-3.6
+        context: variants/2.3.0.0-alpine-3.6
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v2-3-0-0-alpine-3-6.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-3-0-0-alpine-3-6.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-3-0-0-alpine-3-6.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-3-0-0-alpine-3-6.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v2.3.0.0-alpine-3.6 - Build and push (master)
+    - name: 2.3.0.0-alpine-3.6 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v2.3.0.0-alpine-3.6
+        context: variants/2.3.0.0-alpine-3.6
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v2-3-0-0-alpine-3-6.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-3-0-0-alpine-3-6.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-3-0-0-alpine-3-6.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-3-0-0-alpine-3-6.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v2.3.0.0-alpine-3.6 - Build and push (release)
+    - name: 2.3.0.0-alpine-3.6 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v2.3.0.0-alpine-3.6
+        context: variants/2.3.0.0-alpine-3.6
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v2-3-0-0-alpine-3-6.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-3-0-0-alpine-3-6.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-3-0-0-alpine-3-6.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-3-0-0-alpine-3-6.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-3-0-0-alpine-3-6.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-3-0-0-alpine-3-6.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v2-3-0-0-sops-ssh-alpine-3-6
+      id: prep-2-3-0-0-sops-ssh-alpine-3-6
       run: |
         set -e
 
@@ -2206,7 +2206,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v2.3.0.0-sops-ssh-alpine-3.6"
+        VARIANT="2.3.0.0-sops-ssh-alpine-3.6"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -2216,45 +2216,45 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v2.3.0.0-sops-ssh-alpine-3.6 - Build (PRs)
+    - name: 2.3.0.0-sops-ssh-alpine-3.6 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v2.3.0.0-sops-ssh-alpine-3.6
+        context: variants/2.3.0.0-sops-ssh-alpine-3.6
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v2-3-0-0-sops-ssh-alpine-3-6.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-3-0-0-sops-ssh-alpine-3-6.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-3-0-0-sops-ssh-alpine-3-6.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-3-0-0-sops-ssh-alpine-3-6.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v2.3.0.0-sops-ssh-alpine-3.6 - Build and push (master)
+    - name: 2.3.0.0-sops-ssh-alpine-3.6 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v2.3.0.0-sops-ssh-alpine-3.6
+        context: variants/2.3.0.0-sops-ssh-alpine-3.6
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v2-3-0-0-sops-ssh-alpine-3-6.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-3-0-0-sops-ssh-alpine-3-6.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-3-0-0-sops-ssh-alpine-3-6.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-3-0-0-sops-ssh-alpine-3-6.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v2.3.0.0-sops-ssh-alpine-3.6 - Build and push (release)
+    - name: 2.3.0.0-sops-ssh-alpine-3.6 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v2.3.0.0-sops-ssh-alpine-3.6
+        context: variants/2.3.0.0-sops-ssh-alpine-3.6
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v2-3-0-0-sops-ssh-alpine-3-6.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-3-0-0-sops-ssh-alpine-3-6.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v2-3-0-0-sops-ssh-alpine-3-6.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-3-0-0-sops-ssh-alpine-3-6.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-3-0-0-sops-ssh-alpine-3-6.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-2-3-0-0-sops-ssh-alpine-3-6.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 

--- a/README.md
+++ b/README.md
@@ -10,30 +10,30 @@ Dockerized `ansible` with useful tools.
 
 | Tag | Dockerfile Build Context |
 |:-------:|:---------:|
-| `:v8.4.0-alpine-edge`, `:latest` | [View](variants/v8.4.0-alpine-edge) |
-| `:v8.4.0-sops-ssh-alpine-edge` | [View](variants/v8.4.0-sops-ssh-alpine-edge) |
-| `:v7.5.0-alpine-3.18` | [View](variants/v7.5.0-alpine-3.18) |
-| `:v7.5.0-sops-ssh-alpine-3.18` | [View](variants/v7.5.0-sops-ssh-alpine-3.18) |
-| `:v6.6.0-alpine-3.17` | [View](variants/v6.6.0-alpine-3.17) |
-| `:v6.6.0-sops-ssh-alpine-3.17` | [View](variants/v6.6.0-sops-ssh-alpine-3.17) |
-| `:v5.8.0-alpine-3.16` | [View](variants/v5.8.0-alpine-3.16) |
-| `:v5.8.0-sops-ssh-alpine-3.16` | [View](variants/v5.8.0-sops-ssh-alpine-3.16) |
-| `:v4.8.0-alpine-3.15` | [View](variants/v4.8.0-alpine-3.15) |
-| `:v4.8.0-sops-ssh-alpine-3.15` | [View](variants/v4.8.0-sops-ssh-alpine-3.15) |
-| `:v2.10.7-alpine-3.13` | [View](variants/v2.10.7-alpine-3.13) |
-| `:v2.10.7-sops-ssh-alpine-3.13` | [View](variants/v2.10.7-sops-ssh-alpine-3.13) |
-| `:v2.9.18-alpine-3.11` | [View](variants/v2.9.18-alpine-3.11) |
-| `:v2.9.18-sops-ssh-alpine-3.11` | [View](variants/v2.9.18-sops-ssh-alpine-3.11) |
-| `:v2.8.19-alpine-3.10` | [View](variants/v2.8.19-alpine-3.10) |
-| `:v2.8.19-sops-ssh-alpine-3.10` | [View](variants/v2.8.19-sops-ssh-alpine-3.10) |
-| `:v2.7.17-alpine-3.9` | [View](variants/v2.7.17-alpine-3.9) |
-| `:v2.7.17-sops-ssh-alpine-3.9` | [View](variants/v2.7.17-sops-ssh-alpine-3.9) |
-| `:v2.6.20-alpine-3.8` | [View](variants/v2.6.20-alpine-3.8) |
-| `:v2.6.20-sops-ssh-alpine-3.8` | [View](variants/v2.6.20-sops-ssh-alpine-3.8) |
-| `:v2.4.6.0-alpine-3.7` | [View](variants/v2.4.6.0-alpine-3.7) |
-| `:v2.4.6.0-sops-ssh-alpine-3.7` | [View](variants/v2.4.6.0-sops-ssh-alpine-3.7) |
-| `:v2.3.0.0-alpine-3.6` | [View](variants/v2.3.0.0-alpine-3.6) |
-| `:v2.3.0.0-sops-ssh-alpine-3.6` | [View](variants/v2.3.0.0-sops-ssh-alpine-3.6) |
+| `:8.4.0-alpine-edge`, `:latest` | [View](variants/8.4.0-alpine-edge) |
+| `:8.4.0-sops-ssh-alpine-edge` | [View](variants/8.4.0-sops-ssh-alpine-edge) |
+| `:7.5.0-alpine-3.18` | [View](variants/7.5.0-alpine-3.18) |
+| `:7.5.0-sops-ssh-alpine-3.18` | [View](variants/7.5.0-sops-ssh-alpine-3.18) |
+| `:6.6.0-alpine-3.17` | [View](variants/6.6.0-alpine-3.17) |
+| `:6.6.0-sops-ssh-alpine-3.17` | [View](variants/6.6.0-sops-ssh-alpine-3.17) |
+| `:5.8.0-alpine-3.16` | [View](variants/5.8.0-alpine-3.16) |
+| `:5.8.0-sops-ssh-alpine-3.16` | [View](variants/5.8.0-sops-ssh-alpine-3.16) |
+| `:4.8.0-alpine-3.15` | [View](variants/4.8.0-alpine-3.15) |
+| `:4.8.0-sops-ssh-alpine-3.15` | [View](variants/4.8.0-sops-ssh-alpine-3.15) |
+| `:2.10.7-alpine-3.13` | [View](variants/2.10.7-alpine-3.13) |
+| `:2.10.7-sops-ssh-alpine-3.13` | [View](variants/2.10.7-sops-ssh-alpine-3.13) |
+| `:2.9.18-alpine-3.11` | [View](variants/2.9.18-alpine-3.11) |
+| `:2.9.18-sops-ssh-alpine-3.11` | [View](variants/2.9.18-sops-ssh-alpine-3.11) |
+| `:2.8.19-alpine-3.10` | [View](variants/2.8.19-alpine-3.10) |
+| `:2.8.19-sops-ssh-alpine-3.10` | [View](variants/2.8.19-sops-ssh-alpine-3.10) |
+| `:2.7.17-alpine-3.9` | [View](variants/2.7.17-alpine-3.9) |
+| `:2.7.17-sops-ssh-alpine-3.9` | [View](variants/2.7.17-sops-ssh-alpine-3.9) |
+| `:2.6.20-alpine-3.8` | [View](variants/2.6.20-alpine-3.8) |
+| `:2.6.20-sops-ssh-alpine-3.8` | [View](variants/2.6.20-sops-ssh-alpine-3.8) |
+| `:2.4.6.0-alpine-3.7` | [View](variants/2.4.6.0-alpine-3.7) |
+| `:2.4.6.0-sops-ssh-alpine-3.7` | [View](variants/2.4.6.0-sops-ssh-alpine-3.7) |
+| `:2.3.0.0-alpine-3.6` | [View](variants/2.3.0.0-alpine-3.6) |
+| `:2.3.0.0-sops-ssh-alpine-3.6` | [View](variants/2.3.0.0-sops-ssh-alpine-3.6) |
 
 ## Development
 

--- a/generate/definitions/VARIANTS.ps1
+++ b/generate/definitions/VARIANTS.ps1
@@ -144,9 +144,9 @@ $VARIANTS = @(
                     components = $subVariant['components']
                     job_group_key = $variant['package_version']
                 }
-                # Docker image tag. E.g. 'v2.3.0.0-alpine-3.6'
+                # Docker image tag. E.g. '7.5.0-alpine-3.18'
                 tag = @(
-                        "v$( $variant['package_version'] )"
+                        $variant['package_version']
                         $subVariant['components'] | ? { $_ }
                         $variant['distro']
                         $variant['distro_version']

--- a/variants/2.10.7-alpine-3.13/Dockerfile
+++ b/variants/2.10.7-alpine-3.13/Dockerfile
@@ -1,0 +1,16 @@
+FROM alpine:3.13
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+
+# Install ansible
+RUN set -eux; \
+    apk add --no-cache ansible~=2.10.7; \
+    ansible --version
+
+RUN apk add --no-cache ca-certificates
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x docker-entrypoint.sh
+
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/variants/2.10.7-alpine-3.13/docker-entrypoint.sh
+++ b/variants/2.10.7-alpine-3.13/docker-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ] && [ "${1#-}" != "$1" ]; then
+    set -- ansible "$@"
+fi
+
+exec "$@"

--- a/variants/2.10.7-sops-ssh-alpine-3.13/Dockerfile
+++ b/variants/2.10.7-sops-ssh-alpine-3.13/Dockerfile
@@ -1,0 +1,26 @@
+FROM alpine:3.13
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+
+# Install ansible
+RUN set -eux; \
+    apk add --no-cache ansible~=2.10.7; \
+    ansible --version
+
+RUN apk add --no-cache ca-certificates
+
+RUN set -eux; \
+    wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops; \
+    chmod +x /usr/local/bin/sops; \
+    sha256sum /usr/local/bin/sops | grep '^185348fd77fc160d5bdf3cd20ecbc796163504fd3df196d7cb29000773657b74 '; \
+    sops --version
+
+RUN apk add --no-cache gnupg
+
+RUN apk add --no-cache openssh-client
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x docker-entrypoint.sh
+
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/variants/2.10.7-sops-ssh-alpine-3.13/docker-entrypoint.sh
+++ b/variants/2.10.7-sops-ssh-alpine-3.13/docker-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ] && [ "${1#-}" != "$1" ]; then
+    set -- ansible "$@"
+fi
+
+exec "$@"

--- a/variants/2.3.0.0-alpine-3.6/Dockerfile
+++ b/variants/2.3.0.0-alpine-3.6/Dockerfile
@@ -1,0 +1,16 @@
+FROM alpine:3.6
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+
+# Install ansible
+RUN set -eux; \
+    apk add --no-cache ansible>=2.3.0.0; \
+    ansible --version
+
+RUN apk add --no-cache ca-certificates
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x docker-entrypoint.sh
+
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/variants/2.3.0.0-alpine-3.6/docker-entrypoint.sh
+++ b/variants/2.3.0.0-alpine-3.6/docker-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ] && [ "${1#-}" != "$1" ]; then
+    set -- ansible "$@"
+fi
+
+exec "$@"

--- a/variants/2.3.0.0-sops-ssh-alpine-3.6/Dockerfile
+++ b/variants/2.3.0.0-sops-ssh-alpine-3.6/Dockerfile
@@ -1,0 +1,29 @@
+FROM alpine:3.6
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+
+# Install ansible
+RUN set -eux; \
+    apk add --no-cache ansible>=2.3.0.0; \
+    ansible --version
+
+RUN apk add --no-cache ca-certificates
+
+# Fix wget not working in alpine:3.6. https://github.com/gliderlabs/docker-alpine/issues/423
+RUN apk add --no-cache libressl
+
+RUN set -eux; \
+    wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops; \
+    chmod +x /usr/local/bin/sops; \
+    sha256sum /usr/local/bin/sops | grep '^185348fd77fc160d5bdf3cd20ecbc796163504fd3df196d7cb29000773657b74 '; \
+    sops --version
+
+RUN apk add --no-cache gnupg
+
+RUN apk add --no-cache openssh-client
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x docker-entrypoint.sh
+
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/variants/2.3.0.0-sops-ssh-alpine-3.6/docker-entrypoint.sh
+++ b/variants/2.3.0.0-sops-ssh-alpine-3.6/docker-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ] && [ "${1#-}" != "$1" ]; then
+    set -- ansible "$@"
+fi
+
+exec "$@"

--- a/variants/2.4.6.0-alpine-3.7/Dockerfile
+++ b/variants/2.4.6.0-alpine-3.7/Dockerfile
@@ -1,0 +1,16 @@
+FROM alpine:3.7
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+
+# Install ansible
+RUN set -eux; \
+    apk add --no-cache ansible~=2.4.6.0; \
+    ansible --version
+
+RUN apk add --no-cache ca-certificates
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x docker-entrypoint.sh
+
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/variants/2.4.6.0-alpine-3.7/docker-entrypoint.sh
+++ b/variants/2.4.6.0-alpine-3.7/docker-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ] && [ "${1#-}" != "$1" ]; then
+    set -- ansible "$@"
+fi
+
+exec "$@"

--- a/variants/2.4.6.0-sops-ssh-alpine-3.7/Dockerfile
+++ b/variants/2.4.6.0-sops-ssh-alpine-3.7/Dockerfile
@@ -1,0 +1,26 @@
+FROM alpine:3.7
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+
+# Install ansible
+RUN set -eux; \
+    apk add --no-cache ansible~=2.4.6.0; \
+    ansible --version
+
+RUN apk add --no-cache ca-certificates
+
+RUN set -eux; \
+    wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops; \
+    chmod +x /usr/local/bin/sops; \
+    sha256sum /usr/local/bin/sops | grep '^185348fd77fc160d5bdf3cd20ecbc796163504fd3df196d7cb29000773657b74 '; \
+    sops --version
+
+RUN apk add --no-cache gnupg
+
+RUN apk add --no-cache openssh-client
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x docker-entrypoint.sh
+
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/variants/2.4.6.0-sops-ssh-alpine-3.7/docker-entrypoint.sh
+++ b/variants/2.4.6.0-sops-ssh-alpine-3.7/docker-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ] && [ "${1#-}" != "$1" ]; then
+    set -- ansible "$@"
+fi
+
+exec "$@"

--- a/variants/2.6.20-alpine-3.8/Dockerfile
+++ b/variants/2.6.20-alpine-3.8/Dockerfile
@@ -1,0 +1,16 @@
+FROM alpine:3.8
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+
+# Install ansible
+RUN set -eux; \
+    apk add --no-cache ansible~=2.6.20; \
+    ansible --version
+
+RUN apk add --no-cache ca-certificates
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x docker-entrypoint.sh
+
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/variants/2.6.20-alpine-3.8/docker-entrypoint.sh
+++ b/variants/2.6.20-alpine-3.8/docker-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ] && [ "${1#-}" != "$1" ]; then
+    set -- ansible "$@"
+fi
+
+exec "$@"

--- a/variants/2.6.20-sops-ssh-alpine-3.8/Dockerfile
+++ b/variants/2.6.20-sops-ssh-alpine-3.8/Dockerfile
@@ -1,0 +1,26 @@
+FROM alpine:3.8
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+
+# Install ansible
+RUN set -eux; \
+    apk add --no-cache ansible~=2.6.20; \
+    ansible --version
+
+RUN apk add --no-cache ca-certificates
+
+RUN set -eux; \
+    wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops; \
+    chmod +x /usr/local/bin/sops; \
+    sha256sum /usr/local/bin/sops | grep '^185348fd77fc160d5bdf3cd20ecbc796163504fd3df196d7cb29000773657b74 '; \
+    sops --version
+
+RUN apk add --no-cache gnupg
+
+RUN apk add --no-cache openssh-client
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x docker-entrypoint.sh
+
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/variants/2.6.20-sops-ssh-alpine-3.8/docker-entrypoint.sh
+++ b/variants/2.6.20-sops-ssh-alpine-3.8/docker-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ] && [ "${1#-}" != "$1" ]; then
+    set -- ansible "$@"
+fi
+
+exec "$@"

--- a/variants/2.7.17-alpine-3.9/Dockerfile
+++ b/variants/2.7.17-alpine-3.9/Dockerfile
@@ -1,0 +1,16 @@
+FROM alpine:3.9
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+
+# Install ansible
+RUN set -eux; \
+    apk add --no-cache ansible~=2.7.17; \
+    ansible --version
+
+RUN apk add --no-cache ca-certificates
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x docker-entrypoint.sh
+
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/variants/2.7.17-alpine-3.9/docker-entrypoint.sh
+++ b/variants/2.7.17-alpine-3.9/docker-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ] && [ "${1#-}" != "$1" ]; then
+    set -- ansible "$@"
+fi
+
+exec "$@"

--- a/variants/2.7.17-sops-ssh-alpine-3.9/Dockerfile
+++ b/variants/2.7.17-sops-ssh-alpine-3.9/Dockerfile
@@ -1,0 +1,26 @@
+FROM alpine:3.9
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+
+# Install ansible
+RUN set -eux; \
+    apk add --no-cache ansible~=2.7.17; \
+    ansible --version
+
+RUN apk add --no-cache ca-certificates
+
+RUN set -eux; \
+    wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops; \
+    chmod +x /usr/local/bin/sops; \
+    sha256sum /usr/local/bin/sops | grep '^185348fd77fc160d5bdf3cd20ecbc796163504fd3df196d7cb29000773657b74 '; \
+    sops --version
+
+RUN apk add --no-cache gnupg
+
+RUN apk add --no-cache openssh-client
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x docker-entrypoint.sh
+
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/variants/2.7.17-sops-ssh-alpine-3.9/docker-entrypoint.sh
+++ b/variants/2.7.17-sops-ssh-alpine-3.9/docker-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ] && [ "${1#-}" != "$1" ]; then
+    set -- ansible "$@"
+fi
+
+exec "$@"

--- a/variants/2.8.19-alpine-3.10/Dockerfile
+++ b/variants/2.8.19-alpine-3.10/Dockerfile
@@ -1,0 +1,16 @@
+FROM alpine:3.10
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+
+# Install ansible
+RUN set -eux; \
+    apk add --no-cache ansible~=2.8.19; \
+    ansible --version
+
+RUN apk add --no-cache ca-certificates
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x docker-entrypoint.sh
+
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/variants/2.8.19-alpine-3.10/docker-entrypoint.sh
+++ b/variants/2.8.19-alpine-3.10/docker-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ] && [ "${1#-}" != "$1" ]; then
+    set -- ansible "$@"
+fi
+
+exec "$@"

--- a/variants/2.8.19-sops-ssh-alpine-3.10/Dockerfile
+++ b/variants/2.8.19-sops-ssh-alpine-3.10/Dockerfile
@@ -1,0 +1,26 @@
+FROM alpine:3.10
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+
+# Install ansible
+RUN set -eux; \
+    apk add --no-cache ansible~=2.8.19; \
+    ansible --version
+
+RUN apk add --no-cache ca-certificates
+
+RUN set -eux; \
+    wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops; \
+    chmod +x /usr/local/bin/sops; \
+    sha256sum /usr/local/bin/sops | grep '^185348fd77fc160d5bdf3cd20ecbc796163504fd3df196d7cb29000773657b74 '; \
+    sops --version
+
+RUN apk add --no-cache gnupg
+
+RUN apk add --no-cache openssh-client
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x docker-entrypoint.sh
+
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/variants/2.8.19-sops-ssh-alpine-3.10/docker-entrypoint.sh
+++ b/variants/2.8.19-sops-ssh-alpine-3.10/docker-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ] && [ "${1#-}" != "$1" ]; then
+    set -- ansible "$@"
+fi
+
+exec "$@"

--- a/variants/2.9.18-alpine-3.11/Dockerfile
+++ b/variants/2.9.18-alpine-3.11/Dockerfile
@@ -1,0 +1,16 @@
+FROM alpine:3.11
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+
+# Install ansible
+RUN set -eux; \
+    apk add --no-cache ansible~=2.9.18; \
+    ansible --version
+
+RUN apk add --no-cache ca-certificates
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x docker-entrypoint.sh
+
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/variants/2.9.18-alpine-3.11/docker-entrypoint.sh
+++ b/variants/2.9.18-alpine-3.11/docker-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ] && [ "${1#-}" != "$1" ]; then
+    set -- ansible "$@"
+fi
+
+exec "$@"

--- a/variants/2.9.18-sops-ssh-alpine-3.11/Dockerfile
+++ b/variants/2.9.18-sops-ssh-alpine-3.11/Dockerfile
@@ -1,0 +1,26 @@
+FROM alpine:3.11
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+
+# Install ansible
+RUN set -eux; \
+    apk add --no-cache ansible~=2.9.18; \
+    ansible --version
+
+RUN apk add --no-cache ca-certificates
+
+RUN set -eux; \
+    wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops; \
+    chmod +x /usr/local/bin/sops; \
+    sha256sum /usr/local/bin/sops | grep '^185348fd77fc160d5bdf3cd20ecbc796163504fd3df196d7cb29000773657b74 '; \
+    sops --version
+
+RUN apk add --no-cache gnupg
+
+RUN apk add --no-cache openssh-client
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x docker-entrypoint.sh
+
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/variants/2.9.18-sops-ssh-alpine-3.11/docker-entrypoint.sh
+++ b/variants/2.9.18-sops-ssh-alpine-3.11/docker-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ] && [ "${1#-}" != "$1" ]; then
+    set -- ansible "$@"
+fi
+
+exec "$@"

--- a/variants/4.8.0-alpine-3.15/Dockerfile
+++ b/variants/4.8.0-alpine-3.15/Dockerfile
@@ -1,0 +1,16 @@
+FROM alpine:3.15
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+
+# Install ansible
+RUN set -eux; \
+    apk add --no-cache ansible~=4.8.0; \
+    ansible --version
+
+RUN apk add --no-cache ca-certificates
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x docker-entrypoint.sh
+
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/variants/4.8.0-alpine-3.15/docker-entrypoint.sh
+++ b/variants/4.8.0-alpine-3.15/docker-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ] && [ "${1#-}" != "$1" ]; then
+    set -- ansible "$@"
+fi
+
+exec "$@"

--- a/variants/4.8.0-sops-ssh-alpine-3.15/Dockerfile
+++ b/variants/4.8.0-sops-ssh-alpine-3.15/Dockerfile
@@ -1,0 +1,26 @@
+FROM alpine:3.15
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+
+# Install ansible
+RUN set -eux; \
+    apk add --no-cache ansible~=4.8.0; \
+    ansible --version
+
+RUN apk add --no-cache ca-certificates
+
+RUN set -eux; \
+    wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops; \
+    chmod +x /usr/local/bin/sops; \
+    sha256sum /usr/local/bin/sops | grep '^185348fd77fc160d5bdf3cd20ecbc796163504fd3df196d7cb29000773657b74 '; \
+    sops --version
+
+RUN apk add --no-cache gnupg
+
+RUN apk add --no-cache openssh-client
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x docker-entrypoint.sh
+
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/variants/4.8.0-sops-ssh-alpine-3.15/docker-entrypoint.sh
+++ b/variants/4.8.0-sops-ssh-alpine-3.15/docker-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ] && [ "${1#-}" != "$1" ]; then
+    set -- ansible "$@"
+fi
+
+exec "$@"

--- a/variants/5.8.0-alpine-3.16/Dockerfile
+++ b/variants/5.8.0-alpine-3.16/Dockerfile
@@ -1,0 +1,16 @@
+FROM alpine:3.16
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+
+# Install ansible
+RUN set -eux; \
+    apk add --no-cache ansible~=5.8.0; \
+    ansible --version
+
+RUN apk add --no-cache ca-certificates
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x docker-entrypoint.sh
+
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/variants/5.8.0-alpine-3.16/docker-entrypoint.sh
+++ b/variants/5.8.0-alpine-3.16/docker-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ] && [ "${1#-}" != "$1" ]; then
+    set -- ansible "$@"
+fi
+
+exec "$@"

--- a/variants/5.8.0-sops-ssh-alpine-3.16/Dockerfile
+++ b/variants/5.8.0-sops-ssh-alpine-3.16/Dockerfile
@@ -1,0 +1,26 @@
+FROM alpine:3.16
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+
+# Install ansible
+RUN set -eux; \
+    apk add --no-cache ansible~=5.8.0; \
+    ansible --version
+
+RUN apk add --no-cache ca-certificates
+
+RUN set -eux; \
+    wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops; \
+    chmod +x /usr/local/bin/sops; \
+    sha256sum /usr/local/bin/sops | grep '^185348fd77fc160d5bdf3cd20ecbc796163504fd3df196d7cb29000773657b74 '; \
+    sops --version
+
+RUN apk add --no-cache gnupg
+
+RUN apk add --no-cache openssh-client
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x docker-entrypoint.sh
+
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/variants/5.8.0-sops-ssh-alpine-3.16/docker-entrypoint.sh
+++ b/variants/5.8.0-sops-ssh-alpine-3.16/docker-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ] && [ "${1#-}" != "$1" ]; then
+    set -- ansible "$@"
+fi
+
+exec "$@"

--- a/variants/6.6.0-alpine-3.17/Dockerfile
+++ b/variants/6.6.0-alpine-3.17/Dockerfile
@@ -1,0 +1,16 @@
+FROM alpine:3.17
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+
+# Install ansible
+RUN set -eux; \
+    apk add --no-cache ansible~=6.6.0; \
+    ansible --version
+
+RUN apk add --no-cache ca-certificates
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x docker-entrypoint.sh
+
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/variants/6.6.0-alpine-3.17/docker-entrypoint.sh
+++ b/variants/6.6.0-alpine-3.17/docker-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ] && [ "${1#-}" != "$1" ]; then
+    set -- ansible "$@"
+fi
+
+exec "$@"

--- a/variants/6.6.0-sops-ssh-alpine-3.17/Dockerfile
+++ b/variants/6.6.0-sops-ssh-alpine-3.17/Dockerfile
@@ -1,0 +1,26 @@
+FROM alpine:3.17
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+
+# Install ansible
+RUN set -eux; \
+    apk add --no-cache ansible~=6.6.0; \
+    ansible --version
+
+RUN apk add --no-cache ca-certificates
+
+RUN set -eux; \
+    wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops; \
+    chmod +x /usr/local/bin/sops; \
+    sha256sum /usr/local/bin/sops | grep '^185348fd77fc160d5bdf3cd20ecbc796163504fd3df196d7cb29000773657b74 '; \
+    sops --version
+
+RUN apk add --no-cache gnupg
+
+RUN apk add --no-cache openssh-client
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x docker-entrypoint.sh
+
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/variants/6.6.0-sops-ssh-alpine-3.17/docker-entrypoint.sh
+++ b/variants/6.6.0-sops-ssh-alpine-3.17/docker-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ] && [ "${1#-}" != "$1" ]; then
+    set -- ansible "$@"
+fi
+
+exec "$@"

--- a/variants/7.5.0-alpine-3.18/Dockerfile
+++ b/variants/7.5.0-alpine-3.18/Dockerfile
@@ -1,0 +1,16 @@
+FROM alpine:3.18
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+
+# Install ansible
+RUN set -eux; \
+    apk add --no-cache ansible~=7.5.0; \
+    ansible --version
+
+RUN apk add --no-cache ca-certificates
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x docker-entrypoint.sh
+
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/variants/7.5.0-alpine-3.18/docker-entrypoint.sh
+++ b/variants/7.5.0-alpine-3.18/docker-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ] && [ "${1#-}" != "$1" ]; then
+    set -- ansible "$@"
+fi
+
+exec "$@"

--- a/variants/7.5.0-sops-ssh-alpine-3.18/Dockerfile
+++ b/variants/7.5.0-sops-ssh-alpine-3.18/Dockerfile
@@ -1,0 +1,26 @@
+FROM alpine:3.18
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+
+# Install ansible
+RUN set -eux; \
+    apk add --no-cache ansible~=7.5.0; \
+    ansible --version
+
+RUN apk add --no-cache ca-certificates
+
+RUN set -eux; \
+    wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops; \
+    chmod +x /usr/local/bin/sops; \
+    sha256sum /usr/local/bin/sops | grep '^185348fd77fc160d5bdf3cd20ecbc796163504fd3df196d7cb29000773657b74 '; \
+    sops --version
+
+RUN apk add --no-cache gnupg
+
+RUN apk add --no-cache openssh-client
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x docker-entrypoint.sh
+
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/variants/7.5.0-sops-ssh-alpine-3.18/docker-entrypoint.sh
+++ b/variants/7.5.0-sops-ssh-alpine-3.18/docker-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ] && [ "${1#-}" != "$1" ]; then
+    set -- ansible "$@"
+fi
+
+exec "$@"

--- a/variants/8.4.0-alpine-edge/Dockerfile
+++ b/variants/8.4.0-alpine-edge/Dockerfile
@@ -1,0 +1,16 @@
+FROM alpine:edge
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+
+# Install ansible
+RUN set -eux; \
+    apk add --no-cache ansible~=8.4.0; \
+    ansible --version
+
+RUN apk add --no-cache ca-certificates
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x docker-entrypoint.sh
+
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/variants/8.4.0-alpine-edge/docker-entrypoint.sh
+++ b/variants/8.4.0-alpine-edge/docker-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ] && [ "${1#-}" != "$1" ]; then
+    set -- ansible "$@"
+fi
+
+exec "$@"

--- a/variants/8.4.0-sops-ssh-alpine-edge/Dockerfile
+++ b/variants/8.4.0-sops-ssh-alpine-edge/Dockerfile
@@ -1,0 +1,26 @@
+FROM alpine:edge
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+
+# Install ansible
+RUN set -eux; \
+    apk add --no-cache ansible~=8.4.0; \
+    ansible --version
+
+RUN apk add --no-cache ca-certificates
+
+RUN set -eux; \
+    wget -qO- https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux > /usr/local/bin/sops; \
+    chmod +x /usr/local/bin/sops; \
+    sha256sum /usr/local/bin/sops | grep '^185348fd77fc160d5bdf3cd20ecbc796163504fd3df196d7cb29000773657b74 '; \
+    sops --version
+
+RUN apk add --no-cache gnupg
+
+RUN apk add --no-cache openssh-client
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x docker-entrypoint.sh
+
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/variants/8.4.0-sops-ssh-alpine-edge/docker-entrypoint.sh
+++ b/variants/8.4.0-sops-ssh-alpine-edge/docker-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -eu
+
+if [ $# -gt 0 ] && [ "${1#-}" != "$1" ]; then
+    set -- ansible "$@"
+fi
+
+exec "$@"


### PR DESCRIPTION
Docker image tag conventions are starting to become clear that it is preferred to omit `v` prefix. While having the `v` prefix in the past might have been common, it is becoming less and less common today, with most of docker official images
(https://github.com/docker-library/official-images) omitting the `v` prefix.
